### PR TITLE
Remove file[] array and file-level hashes.

### DIFF
--- a/schemas/mtf-extension.schema.json
+++ b/schemas/mtf-extension.schema.json
@@ -27,11 +27,6 @@
       "items": { "$ref": "#/$defs/credential" },
       "description": "OAuth/API credential requirements (CD-04, CD-05)"
     },
-    "files": {
-      "type": "array",
-      "items": { "$ref": "#/$defs/fileHash" },
-      "description": "Bundle file hashes for integrity verification (AI-02)"
-    },
     "source": {
       "$ref": "#/$defs/source",
       "description": "Source commit linkage (PR-04)"
@@ -122,27 +117,6 @@
           "type": "boolean",
           "default": true,
           "description": "Whether token refresh is enabled"
-        }
-      },
-      "additionalProperties": false
-    },
-    "fileHash": {
-      "type": "object",
-      "required": ["path", "sha256"],
-      "properties": {
-        "path": {
-          "type": "string",
-          "description": "Relative file path within bundle"
-        },
-        "sha256": {
-          "type": "string",
-          "pattern": "^[a-f0-9]{64}$",
-          "description": "SHA-256 hash"
-        },
-        "size": {
-          "type": "integer",
-          "minimum": 0,
-          "description": "File size in bytes"
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Replace file-level content hashes (AI-02) with registry bundle digest (RG-07)

File-level hashes in the manifest were onerous for publishers and conceptually awkward (can't hash a bundle from inside the bundle). Bundle integrity is better owned by the registry, which computes a SHA-256 digest of the uploaded archive and serves it to clients.

- Reserve AI-02 control ID (placeholder, no longer active)
- Add RG-07 Bundle Digest: registry computes and serves archive digest
- Rework AI-05 to detect unexpected executables via manifest references
- Simplify AI-03 signing envelope (no per-file hashes)
- Simplify IN-01/IN-02 to verify bundle digest instead of file hashes
- Remove `files` field from manifest schema and examples
- Remove `fileHash` definition from JSON schema
- Update appendices, CI/CD examples, and control counts